### PR TITLE
build: Allow all possible JDK editions by default

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -153,19 +153,11 @@ endif
 java_version_str := $(shell unset _JAVA_OPTIONS && java -version 2>&1)
 javac_version_str := $(shell unset _JAVA_OPTIONS && javac -version 2>&1)
 
-# Check for the correct version of java, should be 1.7 by
-# default, and 1.8 if EXPERIMENTAL_USE_JAVA8 is set
-ifneq ($(EXPERIMENTAL_USE_JAVA8),)
-required_version := "1.8.x"
-required_javac_version := "1.8"
-java_version := $(shell echo '$(java_version_str)' | grep 'openjdk .*[ "]1\.8[\. "$$]')
-javac_version := $(shell echo '$(javac_version_str)' | grep '[ "]1\.8[\. "$$]')
-else # default
-required_version := "1.7.x"
-required_javac_version := "1.7"
-java_version := $(shell echo '$(java_version_str)' | grep '^java .*[ "]1\.7[\. "$$]')
-javac_version := $(shell echo '$(javac_version_str)' | grep '[ "]1\.7[\. "$$]')
-endif # if EXPERIMENTAL_USE_JAVA8
+# Check for the correct version of java, should be 1.7 or 1.8
+required_version := "1.7.x or 1.8.x"
+required_javac_version := "1.7 or 1.8"
+java_version := $(shell echo '$(java_version_str)' | grep '[ "]1\.[78][\. "$$]')
+javac_version := $(shell echo '$(javac_version_str)' | grep '[ "]1\.[78][\. "$$]')
 
 ifeq ($(strip $(java_version)),)
 $(info ************************************************************)
@@ -180,39 +172,6 @@ $(info $(space)$(space)$(space)$(space)https://source.android.com/source/initial
 $(info ************************************************************)
 $(error stop)
 endif
-
-# Check for the current JDK.
-#
-# For Java 1.7, we require OpenJDK on linux and Oracle JDK on Mac OS.
-requires_openjdk := false
-ifeq ($(HOST_OS), linux)
-requires_openjdk := true
-endif
-
-
-# Check for the current jdk
-ifeq ($(requires_openjdk), true)
-# The user asked for java7 openjdk, so check that the host
-# java version is really openjdk
-ifeq ($(shell echo '$(java_version_str)' | grep -i openjdk),)
-$(info ************************************************************)
-$(info You asked for an OpenJDK 7 build but your version is)
-$(info $(java_version_str).)
-$(info ************************************************************)
-$(error stop)
-endif # java version is not OpenJdk
-else # if requires_openjdk
-ifneq ($(shell echo '$(java_version_str)' | grep -i openjdk),)
-$(info ************************************************************)
-$(info You are attempting to build with an unsupported JDK.)
-$(info $(space))
-$(info You use OpenJDK but only Sun/Oracle JDK is supported.)
-$(info Please follow the machine setup instructions at)
-$(info $(space)$(space)$(space)$(space)https://source.android.com/source/download.html)
-$(info ************************************************************)
-$(error stop)
-endif # java version is not Sun Oracle JDK
-endif # if requires_openjdk
 
 # Check for the correct version of javac
 ifeq ($(strip $(javac_version)),)


### PR DESCRIPTION
JDK 7 or JDK 8?
Oracle JDK or OpenJDK?

Who cares? CM builds and works just fine with any one of them!
Drop EXPERIMENTAL_USE_JAVA8 and OpenJDK checks to allow all of them.

Change-Id: I64d7887c2fab4dd301b07d7df0d19f28e97d80ab