### PR TITLE
build: Source a CM-specific global BoardConfig

### DIFF
--- a/core/config.mk
+++ b/core/config.mk
@@ -187,6 +187,8 @@ FIND_LEAVES_EXCLUDES := $(addprefix --prune=, $(OUT_DIR) $(SCAN_EXCLUDE_DIRS) .r
 $(call project-set-path-variant,recovery,RECOVERY_VARIANT,bootable/recovery)
 
 -include vendor/extra/BoardConfigExtra.mk
+-include vendor/cm/config/BoardConfigCM.mk
+
 # The build system exposes several variables for where to find the kernel
 # headers:
 #   TARGET_DEVICE_KERNEL_HEADERS is automatically created for the current


### PR DESCRIPTION
 * Read vendor/cm/config/BoardConfigCM.mk. Kind of surprised we haven't
   needed this until now.

Change-Id: I91cd89b14f6a5975e91f15dcfce1070502aa3861