### PR TITLE
Revert "envsetup: Always look up JAVA_HOME path"

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -2486,7 +2486,7 @@ function set_java_home() {
                 export JAVA_HOME=$(/usr/libexec/java_home -v 1.7)
                 ;;
             *)
-                export JAVA_HOME=$(dirname $(dirname $(dirname $(readlink -f $(which java)))))
+                export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
                 ;;
         esac
       else
@@ -2495,7 +2495,7 @@ function set_java_home() {
                 export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
                 ;;
             *)
-                export JAVA_HOME=$(dirname $(dirname $(dirname $(readlink -f $(which java)))))
+                export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
                 ;;
         esac
       fi


### PR DESCRIPTION
This breaks, if we have both jdk7 and jdk8 installed on same machine.

This reverts commit 9d59c59ae8e620abd26c4c18f120bdccf3d7bfa8

Change-Id: Id0482d130d5306e797adfeeaeb2efbd1e25aa3ee