### PR TITLE
Revert "envsetup: Always look up JAVA_HOME path"

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -2406,7 +2406,7 @@ function set_java_home() {
               export JAVA_HOME=$(/usr/libexec/java_home -v 1.7)
               ;;
           *)
-              export JAVA_HOME=$(dirname $(dirname $(dirname $(readlink -f $(which java)))))
+              export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
               ;;
       esac
 


### PR DESCRIPTION
This breaks, if we have both jdk7 and jdk8 installed on same machine.

This reverts commit bc9ae3d5c21915c165b2b2cb41d07e1573814254.

Change-Id: Id0482d130d5306e797adfeeaeb2efbd1e25aa3ee