### PR TITLE
build: Require devices to opt-in for SDCLANG

### DIFF
--- a/core/binary.mk
+++ b/core/binary.mk
@@ -264,7 +264,9 @@ my_cppflags := $(my_cpp_std_version) $(my_cppflags)
 
 ifeq ($(SDCLANG),true)
     ifeq ($(my_sdclang),)
-        my_sdclang := true
+        ifeq ($(TARGET_USE_SDCLANG),true)
+            my_sdclang := true
+        endif
     endif
 endif
 


### PR DESCRIPTION
 * Only devices which see a measureable benefit should use this
   since it requires more resources to build.
 * Set TARGET_USE_SDCLANG to true in your BoardConfig if your
   device benefits from it.

Change-Id: I12ee20b0627ff0ca121d653cde482e5449a768cc