### PR TITLE
core: move platform-specific helper macros to target makefiles

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -145,12 +145,6 @@ endif
 # be generated correctly
 include $(BUILD_SYSTEM)/cleanbuild.mk
 
-# Bring in Qualcomm helper macros
-include vendor/cm/build/core/qcom_utils.mk
-
-# Bring in Mediatek helper macros too
-include vendor/cm/build/core/mtk_utils.mk
-
 # Include the google-specific config
 -include vendor/google/build/config.mk
 


### PR DESCRIPTION
* These (qcom specifically) are now needed sooner than we had
  previously been importing them. Move to vendor/cm and include
  them within their <platform>_target.mk makefiles.

Change-Id: I06c6ab66446e2f0b54c245cf6c2cf665b649e0c9