### PR TITLE
Revert "Allow to force disable block based OTAs"

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -2148,9 +2148,6 @@ else
 endif
 	$(hide) echo "ota_override_device=$(OTA_SCRIPT_OVERRIDE_DEVICE)" >> $(zip_root)/META/misc_info.txt
 	$(hide) echo "ota_override_prop=$(OTA_SCRIPT_OVERRIDE_PROP)" >> $(zip_root)/META/misc_info.txt
-ifdef BOARD_DISABLE_BLOCK_BASED_OTA
-	$(hide) echo "disable_block_based_ota=$(BOARD_DISABLE_BLOCK_BASED_OTA)" >> $(zip_root)/META/misc_info.txt
-endif
 ifdef BOARD_PREBUILT_VENDORIMAGE
 	$(hide) mkdir -p $(zip_root)/IMAGES
 	$(hide) cp $(INSTALLED_VENDORIMAGE_TARGET) $(zip_root)/IMAGES/
@@ -2229,9 +2226,7 @@ ifneq ($(TARGET_UNIFIED_DEVICE),)
 endif
 
 ifneq ($(BLOCK_BASED_OTA),false)
-ifneq ($(BOARD_DISABLE_BLOCK_BASED_OTA),true)
     $(INTERNAL_OTA_PACKAGE_TARGET): block_based := --block
-endif
 endif
 
 $(INTERNAL_OTA_PACKAGE_TARGET): $(BUILT_TARGET_FILES_PACKAGE)

--- a/tools/releasetools/ota_from_target_files.py
+++ b/tools/releasetools/ota_from_target_files.py
@@ -2097,11 +2097,6 @@ def main(argv):
   if "ota_override_prop" in OPTIONS.info_dict:
     OPTIONS.override_prop = OPTIONS.info_dict.get("ota_override_prop") == "true"
 
-  disable_block_based_ota = OPTIONS.info_dict.get("disable_block_based_ota") == "true"
-  if OPTIONS.block_based and disable_block_based_ota:
-    print("Block based OTAs are disabled for this device")
-    OPTIONS.block_based = False
-
   ab_update = OPTIONS.info_dict.get("ab_update") == "true"
 
   if ab_update:


### PR DESCRIPTION
This reverts commit 1a03881e6f00fb9f9244c92d52efd972348c8a23.

Recoveries do not use file_contexts.bin, so you're at the mercy of 
their file_contexts file, which isn't guaranteed to be accurate. 

Change-Id: I1941b899b0c719437f36ac5886f0caf3f7ccac6a